### PR TITLE
patch for #37

### DIFF
--- a/Squad Mortar Calculator/Barrage VCs/BarrageTargetViewController.swift
+++ b/Squad Mortar Calculator/Barrage VCs/BarrageTargetViewController.swift
@@ -79,7 +79,7 @@ class BarrageTargetViewController: UIViewController, UITextFieldDelegate, PassBa
             targetYPos = (Double(String(leftTargetField.text![1]))! - 1) * 300
         } else {
             targetYPos = Double(String(leftTargetField.text![1]))! * 3000
-            targetYPos = (Double(String(leftTargetField.text![2]))! - 1) * 300
+            targetYPos += (Double(String(leftTargetField.text![2]))! - 1) * 300
         }
         
         switch Int(middleTargetField.text!)! {

--- a/Squad Mortar Calculator/Calculator VCs/Mortar VCs/MortarViewController.swift
+++ b/Squad Mortar Calculator/Calculator VCs/Mortar VCs/MortarViewController.swift
@@ -80,7 +80,7 @@ class MortarViewController: UIViewController, UITextFieldDelegate, PassMortarLoc
             mortarYPos = (Double(String(leftMortarField.text![1]))! - 1) * 300
         } else {
             mortarYPos = Double(String(leftMortarField.text![1]))! * 3000
-            mortarYPos = (Double(String(leftMortarField.text![2]))! - 1) * 300
+            mortarYPos += (Double(String(leftMortarField.text![2]))! - 1) * 300
         }
         
         // Convert second field to meters and add to sum

--- a/Squad Mortar Calculator/Calculator VCs/Target VCs/TargetViewController.swift
+++ b/Squad Mortar Calculator/Calculator VCs/Target VCs/TargetViewController.swift
@@ -78,7 +78,7 @@ class TargetViewController: UIViewController, UITextFieldDelegate, PassTargetLoc
             targetYPos = (Double(String(leftTargetField.text![1]))! - 1) * 300
         } else {
             targetYPos = Double(String(leftTargetField.text![1]))! * 3000
-            targetYPos = (Double(String(leftTargetField.text![2]))! - 1) * 300
+            targetYPos += (Double(String(leftTargetField.text![2]))! - 1) * 300
         }
         
         switch Int(middleTargetField.text!)! {

--- a/Squad Mortar Calculator/Corrections VCs/CorrectionsTargetViewController.swift
+++ b/Squad Mortar Calculator/Corrections VCs/CorrectionsTargetViewController.swift
@@ -79,7 +79,7 @@ class CorrectionsTargetViewController: UIViewController, UITextFieldDelegate, Pa
             targetYPos = (Double(String(leftTargetField.text![1]))! - 1) * 300
         } else {
             targetYPos = Double(String(leftTargetField.text![1]))! * 3000
-            targetYPos = (Double(String(leftTargetField.text![2]))! - 1) * 300
+            targetYPos += (Double(String(leftTargetField.text![2]))! - 1) * 300
         }
         
         switch Int(middleTargetField.text!)! {

--- a/Squad Mortar Calculator/Info.plist
+++ b/Squad Mortar Calculator/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.1</string>
+	<string>1.0.2</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
The issue was caused by the second digit overriding the calculation rather than adding to the sum. Easy fix for a bug that only occurred when the mortar and target were on either side of the 9-10 coordinate divide

Bypassing develop process as its a small but vital bugfix

Fixes #37 